### PR TITLE
Raw range data to point cloud

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(Protobuf REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common io visualization)
 
 file(GLOB WAYMO_PROTO_SRCS waymo-open-dataset/src/waymo_open_dataset/protos/*.pb.cc)
 file(GLOB WAYMO_SRCS waymo-open-dataset/src/waymo_open_dataset/*.pb.cc)
@@ -13,14 +14,20 @@ file(GLOB WAYMO_SRCS waymo-open-dataset/src/waymo_open_dataset/*.pb.cc)
 include_directories(include)
 include_directories(EIGEN3_INCLUDE_DIR)
 include_directories(${Protobuf_INCLUDE_DIRS})
+include_directories(${PCL_INCLUDE_DIRS})
 include_directories(${ZLIB_DEPS_DIR})
 include_directories(waymo-open-dataset/src)
 include_directories(waymo-open-dataset/src/waymo_open_dataset/protos)
+
+link_directories(${PCL_LIBRARY_DIRS})
+
+add_definitions(${PCL_DEFINITIONS})
 
 # link sources in a single executable
 add_executable(3d_tracker 
     src/main.cpp
     src/lidar_decoder.cpp
+    src/lidar_visualizer.cpp
     src/tfrecords_parser.cpp
     ${WAYMO_PROTO_SRCS}
     ${WAYMO_SRCS}
@@ -28,5 +35,5 @@ add_executable(3d_tracker
 
 # link libraries to executable
 target_link_libraries(3d_tracker
-    ${Protobuf_LIBRARIES} z
+    ${Protobuf_LIBRARIES} z ${PCL_LIBRARIES}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,16 @@ project(3d_tracker)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(Protobuf REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 file(GLOB WAYMO_PROTO_SRCS waymo-open-dataset/src/waymo_open_dataset/protos/*.pb.cc)
 file(GLOB WAYMO_SRCS waymo-open-dataset/src/waymo_open_dataset/*.pb.cc)
 
 # include headers from waymo dataset and include
 include_directories(include)
+include_directories(EIGEN3_INCLUDE_DIR)
 include_directories(${Protobuf_INCLUDE_DIRS})
+include_directories(${ZLIB_DEPS_DIR})
 include_directories(waymo-open-dataset/src)
 include_directories(waymo-open-dataset/src/waymo_open_dataset/protos)
 
@@ -25,5 +28,5 @@ add_executable(3d_tracker
 
 # link libraries to executable
 target_link_libraries(3d_tracker
-    ${Protobuf_LIBRARIES}
+    ${Protobuf_LIBRARIES} z
 )

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Converts raw TFRecords data to usable CompressedFrameLaserData.
 
+## Prerequisites
+
+- C++17 compatible compiler (e.g., GCC 7.0+, Clang 5.0+).
+- CMake 3.10 or higher.
+- Protocol Buffers compiler (`protoc`) version 3.8.0.
+- [Waymo Open Dataset](https://waymo.com/open/) TFRecord files.
+
 ## License
 
 This project is licensed under the Apache 2.0 License. See the [LICENSE](./LICENSE) file for details.

--- a/docs/Notes.md
+++ b/docs/Notes.md
@@ -57,3 +57,5 @@ The final `data` is decoded as a `CompressedFrameLaserData` type.
 Thus, the first step is to decompress the data. Then, PCL has an API to visualize point cloud data. We can take the raw data, convert to point cloud data, and visualize that data. 
 
 We also have to convert the raw range image format (spherical) that comes from the LIDAR to proper 3D xyz coordinates. This data is not readily available. We get zlib-compressed data that is all deltas. From there, we recover the range image with distances and angles. Then, we convert from polar/spherical to cartesian 3D points and do a coordinate transform from LIDAR to world.
+
+export CPLUS_INCLUDE_PATH=/usr/include/eigen3:$CMAKE_PREFIX_PATH

--- a/docs/Notes.md
+++ b/docs/Notes.md
@@ -47,8 +47,13 @@ See [record_writer in tensorflow](https://github.com/tensorflow/tensorflow/blob/
 ## Decode `data` field in TFRecord
 Once the raw data is extracted from the TFRecord, `data` needs to be decoded using the proto classes generated from `protoc`.
 
-This is done with `read_data.hpp/.cpp`.
+This is done with the ParseFromArray function from the protocol buffer C++ API for every frame that came from the tfrecord.
 
-How we are going to do this:
-- Each laser scan has an RI return (Range Image Return, the surface a pulse hits) and there can be many (closest is RI return 1)
-- 
+The final `data` is decoded as a `CompressedFrameLaserData` type.
+
+## Visualizing lidar data
+`CompressedFrameLaserData` has compressed data that needs to be decompressed. They are zlib-compressed, as noted in the `dataset.proto` comments.
+
+Thus, the first step is to decompress the data. Then, PCL has an API to visualize point cloud data. We can take the raw data, convert to point cloud data, and visualize that data. 
+
+We also have to convert the raw range image format (spherical) that comes from the LIDAR to proper 3D xyz coordinates. This data is not readily available. We get zlib-compressed data that is all deltas. From there, we recover the range image with distances and angles. Then, we convert from polar/spherical to cartesian 3D points and do a coordinate transform from LIDAR to world.

--- a/include/lidar_decoder.hpp
+++ b/include/lidar_decoder.hpp
@@ -6,26 +6,37 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <zlib.h>
 #include "waymo_open_dataset/protos/compressed_lidar.pb.h"
 
+#include <Eigen/Dense>
+
+#define TOP_LIDAR 1
 #define DEBUG true
 
 /*
 * lidar_decoder.cpp/hpp takes the vector of frames 
 * and decodes them into usable lidar messages.
+* 
+* Laser being decoded is `waymo::open_dataset::LaserName::TOP`
 */
 
 class LidarDecoder 
 {
 
 private:
-    vector<waymo::open_dataset::CompressedFrameLaserData *> laser_frames;
-    std::string & decompressed_data;
-    std::vector<Eigen::Vector3D>& points;
+    std::vector<waymo::open_dataset::CompressedFrameLaserData *> laser_frames;
+    std::string decompressed_data;
+    std::vector<Eigen::Vector3d> points;
+
+    size_t H;
+    size_t W;
 
 public:
     LidarDecoder();
     void decode_raw_data(TFRecordParser& parser);
+    std::vector<std::vector<std::array<float, 4>>> decompress_laser_data(std::string & compressed_data);
+    void decompressed_data_to_points();
     ~LidarDecoder();
 };
 

--- a/include/lidar_decoder.hpp
+++ b/include/lidar_decoder.hpp
@@ -11,7 +11,7 @@
 
 #include <Eigen/Dense>
 
-#define TOP_LIDAR 1
+#define TOP_LIDAR 0
 #define DEBUG true
 
 using PointCloudPtr = std::shared_ptr<std::vector<Eigen::Vector3d>>;

--- a/include/lidar_decoder.hpp
+++ b/include/lidar_decoder.hpp
@@ -14,6 +14,8 @@
 #define TOP_LIDAR 1
 #define DEBUG true
 
+using PointCloudPtr = std::shared_ptr<std::vector<Eigen::Vector3d>>;
+
 /*
 * lidar_decoder.cpp/hpp takes the vector of frames 
 * and decodes them into usable lidar messages.
@@ -25,18 +27,21 @@ class LidarDecoder
 {
 
 private:
+
+    std::vector<std::vector<std::array<float, 4>>> decompress_laser_data(std::string & compressed_data);
+    void bytes_to_points();
+
     std::vector<waymo::open_dataset::CompressedFrameLaserData *> laser_frames;
     std::string decompressed_data;
-    std::vector<Eigen::Vector3d> points;
+    PointCloudPtr points_ptr;
 
     size_t H;
     size_t W;
 
 public:
-    LidarDecoder();
+    LidarDecoder(PointCloudPtr points_ptr);
     void decode_raw_data(TFRecordParser& parser);
-    std::vector<std::vector<std::array<float, 4>>> decompress_laser_data(std::string & compressed_data);
-    void decompressed_data_to_points();
+    PointCloudPtr get_lidar_points();
     ~LidarDecoder();
 };
 

--- a/include/lidar_decoder.hpp
+++ b/include/lidar_decoder.hpp
@@ -19,12 +19,14 @@ class LidarDecoder
 {
 
 private:
+    vector<waymo::open_dataset::CompressedFrameLaserData *> laser_frames;
+    std::string & decompressed_data;
+    std::vector<Eigen::Vector3D>& points;
 
 public:
     LidarDecoder();
     void decode_raw_data(TFRecordParser& parser);
     ~LidarDecoder();
-
 };
 
 #endif // LIDAR_DECODER_HPP

--- a/include/lidar_visualizer.hpp
+++ b/include/lidar_visualizer.hpp
@@ -5,8 +5,6 @@
 #include <vector>
 #include <string>
 
-#include <zlib>
-#include <Eigen/Dense>
 #include <pcl/visualization/pcl_visualizer.hpp>
 
 /*

--- a/include/lidar_visualizer.hpp
+++ b/include/lidar_visualizer.hpp
@@ -5,7 +5,9 @@
 #include <vector>
 #include <string>
 
-#include <pcl/visualization/pcl_visualizer.hpp>
+#include <pcl/visualization/pcl_visualizer.h>
+
+using PointCloudPtr = std::shared_ptr<std::vector<Eigen::Vector3d>>;
 
 /*
 * lidar_visualizer.cpp/hpp takes raw Eigen::Vector3d 
@@ -16,9 +18,11 @@ class LidarVisualizer
 {
 
 private:
+    
+    PointCloudPtr points_ptr;
 
 public:
-    LidarVisualizer();
+    LidarVisualizer(PointCloudPtr points_ptr);
 
     void visualize_laser_data();
 

--- a/include/lidar_visualizer.hpp
+++ b/include/lidar_visualizer.hpp
@@ -1,0 +1,31 @@
+#ifndef LIDAR_VISUALIZER_HPP
+#define LIDAR_VISUALIZER_HPP
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include <zlib>
+#include <Eigen/Dense>
+#include <pcl/visualization/pcl_visualizer.hpp>
+
+/*
+* lidar_visualizer.cpp/hpp takes raw Eigen::Vector3d 
+* points and visualizes them in a viewer.
+*/
+
+class LidarVisualizer 
+{
+
+private:
+
+public:
+    LidarVisualizer();
+
+    void visualize_laser_data();
+
+    ~LidarVisualizer();
+
+};
+
+#endif // LIDAR_VISUALIZER_HPP

--- a/src/lidar_decoder.cpp
+++ b/src/lidar_decoder.cpp
@@ -7,7 +7,7 @@ void LidarDecoder::decode_raw_data(TFRecordParser& parser)
 
     for(auto frame : parser.frames)
     {
-        waymo::open_dataset::CompressedFrameLaserData lidar_frame;
+        auto * lidar_frame = new waymo::open_dataset::CompressedFrameLaserData();
         if(!lidar_frame.ParseFromArray(frame->data, frame->record_length))
         {
             std::cerr << "Failed to parse lidar data" << std::endl;;
@@ -17,7 +17,157 @@ void LidarDecoder::decode_raw_data(TFRecordParser& parser)
         {
             std::cout << "Lasers Size: "<< lidar_frame.lasers_size() << std::endl;
         }
+        lidar_frames.push_back(lidar_frame);
     }
 }
 
-LidarDecoder::~LidarDecoder() {}
+std::string LidarDecoder::decompress_laser_data(std::string & compressed_data)
+{
+    size_t compressed_size = compressed_data.size();
+
+    size_t decompressed_size = 1024; // one byte
+    std::string decompressed_data(decompressed_data);
+
+    z_stream zs;
+    memset(&zs, 0, sizeof(zs));
+
+    // initialize zlib object
+    if (inflateInit(&zs) != Z_OK) 
+    {
+        std::cerr << "Could not initialize zlib object." << std::endl;
+    }
+
+    // Set input and output buffers
+    zs.next_in = compressed_data.data();
+    zs.avail_in = compressed_size;
+
+    zs.next_out = decompressed_data.data();
+    zs.avail_out = decompressed_size;
+
+    // Decompress
+    int ret = inflate(&zs, Z_FINISH);
+    
+    // error checking
+    if (ret != Z_STREAM_END && ret != Z_OK) 
+    {
+        std::cerr << "zlib inflate error: " << ret << std::endl;
+        // clean up in case of error
+        inflateEnd(&zs);
+    }
+
+    // Get the actual decompressed size
+
+    int actual_decompressed_size = decompressed_size - zs.avail_out;
+
+    // clean up zlib
+    inflateEnd(&zs);
+
+    return decompressed_data;
+}
+
+
+void LidarDecoder::decompressed_data_to_points()
+{
+    // for every laser scan, convert to cartesian
+    for(auto & frame : laser_frames)
+    {
+        // compressed range data to decompressed
+        std::string range_image_delta_compressed = frame->ri_return1()->range_image_delta_compressed();
+        std::vector<std::vector<std::array<float, 4>> range_image_delta = decompress_laser_data(range_image_delta_compressed); // 2D tensor with 4 values
+
+        // compressed transform to decompressed
+        std::string range_image_pose_delta_compressed = frame->ri_return1->range_image_pose_delta_compressed();
+        std::vector<std::vector<std::array<float, 4>> range_image_pose = decompress_laser_data(range_image_pose_delta_compressed);
+
+        size_t H = range_image_delta.size();
+        size_t W = range_image_delta.at(0).size();
+
+        for(size_t i = 0; i < H; ++i)
+        {
+            for(size_t j = 0; j < W; ++j)
+            {
+                // [H][W][range, intensity, elongation, whether range is in no label zone]
+                                                                 
+                /* Polar coodinates: range, horizontal angle (theta), vertical angle (phi) */
+                float range = range_image_delta[i][j][0];
+                float theta = j * ((2 * M_PI) / W);
+                const auto& calibration = frame.laser_calibrations(i);
+
+                // use min-max-value linear interpolation to compute phi
+                double phi_min = calibration.beam_inclination_min();
+                double phi_max = calibration.beam_inclination_max();
+
+                /*
+
+                    [Other LIDARS on the vehicle] that have uniform beam inclinations are only parameterized by the min and max.
+                    https://github.com/tensorflow/lingvo/blob/master/lingvo/tasks/car/waymo/tools/waymo_proto_to_tfe.py#L454 
+
+                    This enables the choice of doing linear interpolation to compute phi from the min and max inclinations.
+
+                    Calculation:
+                    * min value it can be is phi min
+                    * each row has a percentage of the height
+                    * multiply that by the difference between the min and max
+
+                */
+                double phi = phi_min + (i / (H - 1)) * (phi_max - phi_min);
+
+                // spherical to cartesian coordinates
+                float x = range * cos(theta) * cos(phi);
+                float y = range * cos(theta) * sin(phi);
+                float z = range * sin(theta);
+
+                float roll_transform = range_image_pose[i][j][0];
+                float pitch_transform = range_image_pose[i][j][1];
+                float yaw_transform = range_image_pose[i][j][2];
+                float x_transform = range_image_pose[i][j][3];
+                float y_transform = range_image_pose[i][j][4];
+                float z_transform = range_image_pose[i][j][5];
+
+                Eigen::Vector3d translation(x_transform, y_transform, z_transform);
+
+                // transform x y z from lidar to world coordinates, assuming standard convention
+                // https://eigen.tuxfamily.org/dox/group__TutorialGeometry.html
+                Eigen::AngleAxisd rollAngle(roll, Eigen::Vector3d::UnitX());
+                Eigen::AngleAxisd pitchAngle(pitch, Eigen::Vector3d::UnitY());
+                Eigen::AngleAxisd yawAngle(yaw, Eigen::Vector3d::UnitZ());
+
+                Eigen::Matrix4f transform_mat = Eigen::Matrix4f::Identity();
+
+                Eigen::Matrix3d rotation = transform_mat * (yawAngle * pitchAngle * rollAngle);
+
+                transform_mat.block<3,3>(0, 0) = rotation;
+                transform_mat.block<4,1>(0, 3) = translation;
+
+                // perform a homogeneous transformation (4 x 4 * 4 x 1)
+                Eigen::Vector4d point_h(x, y, z, 1.0);
+
+                Eigen::Vector4d transformed_point = transform_mat * point_h;
+
+                // get first 3 values of transformed point
+                points.emplace_back(transformed_point.head<3>());
+
+            }
+        }
+
+        std::cout << "FRAME" << std::endl;
+
+    }
+
+    // decompressed data to DeltaEncodedData -- https://github.com/waymo-research/waymo-open-dataset/blob/master/src/waymo_open_dataset/protos/compressed_lidar.proto#L78
+//    waymo::open_dataset::DeltaEncodedData delta_encoded_data;
+
+    // get delta_encoded_data attributes
+//    auto& residual = delta_encoded_data.residual();
+//    auto& mask = delta_encoded_data.mask();
+//    auto& metadata = delta_encoded_data.metadata();
+
+    std::cout << "Raw lidar ranges to cartesian." << std::endl;
+
+}
+
+
+LidarDecoder::~LidarDecoder() 
+{
+    delete[] lidar_frames;
+}

--- a/src/lidar_decoder.cpp
+++ b/src/lidar_decoder.cpp
@@ -1,10 +1,9 @@
 #include "lidar_decoder.hpp"
 
-LidarDecoder::LidarDecoder()
+LidarDecoder::LidarDecoder(PointCloudPtr points_ptr) : points_ptr(points_ptr)
 {
     laser_frames = {};
     decompressed_data = "";
-    points = {{}};
 }
 
 void LidarDecoder::decode_raw_data(TFRecordParser& parser)
@@ -24,6 +23,10 @@ void LidarDecoder::decode_raw_data(TFRecordParser& parser)
         }
         laser_frames.push_back(laser_frame);
     }
+
+    // raw bytes to points
+    bytes_to_points();
+
 }
 
 std::vector<std::vector<std::array<float, 4>>> LidarDecoder::decompress_laser_data(std::string & compressed_data)
@@ -89,7 +92,7 @@ std::vector<std::vector<std::array<float, 4>>> LidarDecoder::decompress_laser_da
 }
 
 
-void LidarDecoder::decompressed_data_to_points()
+void LidarDecoder::bytes_to_points()
 {
     // for every laser scan, convert to cartesian
     for(auto & frame : laser_frames)
@@ -168,7 +171,7 @@ void LidarDecoder::decompressed_data_to_points()
                 Eigen::Vector4d transformed_point = transform_mat * point_h;
 
                 // get first 3 values of transformed point
-                points.emplace_back(transformed_point.head<3>());
+                points_ptr->emplace_back(transformed_point.head<3>());
 
             }
         }
@@ -181,6 +184,10 @@ void LidarDecoder::decompressed_data_to_points()
 
 }
 
+PointCloudPtr LidarDecoder::get_lidar_points()
+{
+    return points_ptr;
+}
 
 LidarDecoder::~LidarDecoder() 
 {

--- a/src/lidar_visualizer.cpp
+++ b/src/lidar_visualizer.cpp
@@ -20,12 +20,12 @@ void LidarVisualizer::visualize_laser_data()
     *
     */
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
 
-    for(const auto& pt : points_ptr)
+    for(const auto& pt : *points_ptr) // get - returns the raw pointer
     {
         // add points to cloud with emplace_back (in-place push_back)
-        cloud->points_ptr->emplace_back(pt.x(), pt.y(), pt.z());
+        cloud->points.emplace_back(pt.x(), pt.y(), pt.z());
     }
 
     pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer ("3D Viewer"));
@@ -53,14 +53,14 @@ void LidarVisualizer::visualize_laser_data()
     
     viewer->addCoordinateSystem(1.0);
   
-    viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal>(cloud, normals1, 10, 0.05, "normals1", v1);
-    viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal>(cloud, normals2, 10, 0.05, "normals2", v2);
+    //viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal>(cloud, normals1, 10, 0.05, "normals1", v1);
+    //viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal>(cloud, normals2, 10, 0.05, "normals2", v2);
   
     // Run the visualization
-    while (!viewer.wasStopped()) 
+    while (!viewer->wasStopped()) 
     {
-        viewer.spinOnce();
+        viewer->spinOnce();
     }
 
-    delete cloud;
+    //delete cloud;
 }

--- a/src/lidar_visualizer.cpp
+++ b/src/lidar_visualizer.cpp
@@ -1,0 +1,65 @@
+#include <lidar_visualizer.hpp>
+
+
+LidarVisualizer::LidarVisualizer()
+{
+
+}
+
+LidarVisualizer::~LidarVisualizer()
+{
+
+}
+
+void LidarVisualizer::visualize_laser_data()
+{
+
+    /*
+    * https://pcl.readthedocs.io/projects/tutorials/en/master/pcl_visualizer.html
+    *
+    */
+
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+
+    for(const auto& pt : points)
+    {
+        // add points to cloud with emplace_back (in-place push_back)
+        cloud->points.emplace_back(pt.x(), pt.y(), pt.z());
+    }
+
+    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer ("3D Viewer"));
+
+    viewer->initCameraParameters();
+    
+    int v1(0);
+    viewer->createViewPort(0.0, 0.0, 0.5, 1.0, v1);
+    viewer->setBackgroundColor (0, 0, 0, v1);
+    viewer->addText("Radius: 0.01", 10, 10, "v1 text", v1);
+    
+    pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb(cloud);
+    viewer->addPointCloud<pcl::PointXYZRGB> (cloud, rgb, "sample cloud1", v1);
+
+    int v2(0);
+    viewer->createViewPort(0.5, 0.0, 1.0, 1.0, v2);
+    viewer->setBackgroundColor (0.3, 0.3, 0.3, v2);
+
+    viewer->addText("Radius: 0.1", 10, 10, "v2 text", v2);
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZRGB> single_color(cloud, 0, 255, 0);
+    viewer->addPointCloud<pcl::PointXYZRGB> (cloud, single_color, "sample cloud2", v2);
+
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud1");
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud2");
+    
+    viewer->addCoordinateSystem(1.0);
+  
+    viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal>(cloud, normals1, 10, 0.05, "normals1", v1);
+    viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal>(cloud, normals2, 10, 0.05, "normals2", v2);
+  
+    // Run the visualization
+    while (!viewer.wasStopped()) 
+    {
+        viewer.spinOnce();
+    }
+
+    delete cloud;
+}

--- a/src/lidar_visualizer.cpp
+++ b/src/lidar_visualizer.cpp
@@ -1,9 +1,10 @@
 #include <lidar_visualizer.hpp>
 
 
-LidarVisualizer::LidarVisualizer()
+LidarVisualizer::LidarVisualizer(PointCloudPtr points_ptr) : points_ptr(points_ptr)
 {
 
+    
 }
 
 LidarVisualizer::~LidarVisualizer()
@@ -21,10 +22,10 @@ void LidarVisualizer::visualize_laser_data()
 
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
 
-    for(const auto& pt : points)
+    for(const auto& pt : points_ptr)
     {
         // add points to cloud with emplace_back (in-place push_back)
-        cloud->points.emplace_back(pt.x(), pt.y(), pt.z());
+        cloud->points_ptr->emplace_back(pt.x(), pt.y(), pt.z());
     }
 
     pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer ("3D Viewer"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,9 @@
 #include <google/protobuf/stubs/common.h>
 #include "tfrecords_parser.hpp"
 #include "lidar_decoder.hpp"
+#include "lidar_visualizer.hpp"
+
+using PointCloudPtr = std::shared_ptr<std::vector<Eigen::Vector3d>>;
 
 int main (int argc, char * argv[])
 {
@@ -15,13 +18,22 @@ int main (int argc, char * argv[])
         return -1;
     }
 
+    // create a single smart pointer for lidar points - decode & visualize
+    auto points_ptr = std::make_shared<std::vector<Eigen::Vector3d>>();
+
+    // initialize a parser
     TFRecordParser parser(argv[1]);
 
+    // read records into vector of lidar frame structs
     parser.read_records();
 
-    LidarDecoder lidar_decoder;
-
+    // raw data to points that can be visualized
+    LidarDecoder lidar_decoder(points_ptr);
     lidar_decoder.decode_raw_data(parser);
+
+    // viewer
+    LidarVisualizer lidar_visualizer(points_ptr);
+    lidar_visualizer.visualize_laser_data();
 
     return 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,8 @@
 #include "lidar_decoder.hpp"
 #include "lidar_visualizer.hpp"
 
+// shared pointer: https://www.geeksforgeeks.org/shared_ptr-in-cpp/
+
 using PointCloudPtr = std::shared_ptr<std::vector<Eigen::Vector3d>>;
 
 int main (int argc, char * argv[])


### PR DESCRIPTION
This branch raw range bytes parsed from the tfrecords parser to points.

* Further testing needed!!
* zlib compressed data is decompressed
* spherical range data to cartesian points
* uses a provided transform from waymo-open-dataset's compressed_lidar protocol buffer
* class to visualize the point clouds